### PR TITLE
ch 1.1 초난감 DAO 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,8 +13,18 @@ repositories {
 }
 
 dependencies {
+    // Lombok
     implementation("org.projectlombok:lombok:1.18.24")
     annotationProcessor("org.projectlombok:lombok:1.18.24")
+
+    // Mysql Connector
+    implementation("mysql:mysql-connector-java:8.0.30")
+
+    // Test Junit5 & AssertJ
+    testImplementation("org.junit.jupiter:junit-jupiter-api:5.9.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.9.0")
+    testImplementation("org.assertj:assertj-core:3.23.1")
+
 }
 
 tasks.getByName<Test>("test") {

--- a/src/main/java/springbook/vol1/ch1/dao/UserDao.java
+++ b/src/main/java/springbook/vol1/ch1/dao/UserDao.java
@@ -1,0 +1,67 @@
+package springbook.vol1.ch1.dao;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import springbook.vol1.ch1.domain.User;
+
+/**
+ * JDBC 4.0 이후부터 Class.forName()사용하여 JDBC 드라이버를 로딩할 필요가 없어졌다. 왜냐하면 SPI가 JDBC 드라이버는 자동으로 로딩되기 때문이다.
+ * (SPI: Service Provider Interface)
+ */
+public class UserDao {
+
+	public void add(User user) throws SQLException {
+//		Class.forName("com.mysql.jdbc.Driver");
+		Connection con = DriverManager.getConnection(
+			"jdbc:mysql://localhost/springbook", "spring", "book");
+
+		PreparedStatement ps = con.prepareStatement(
+			"insert into users(id, name, password) values(?, ?, ?)");
+
+		ps.setString(1, user.getId());
+		ps.setString(2, user.getName());
+		ps.setString(3, user.getPassword());
+
+		ps.executeUpdate();
+		ps.close();
+		con.close();
+	}
+
+	public User get(String id) throws SQLException {
+//		Class.forName("com.mysql.jdbc.Driver");
+		Connection con = DriverManager.getConnection(
+			"jdbc:mysql://localhost/springbook?characterEncoding=UTF-8", "spring",
+			"book");
+
+		PreparedStatement ps = con.prepareStatement("select * from users where id = ?");
+		ps.setString(1, id);
+
+		ResultSet rs = ps.executeQuery();
+		rs.next();
+		User user = new User();
+		user.setId(rs.getString("id"));
+		user.setName(rs.getString("name"));
+		user.setPassword(rs.getString("password"));
+
+		rs.close();
+		ps.close();
+		con.close();
+
+		return user;
+	}
+
+	public void clean() throws SQLException {
+		Connection con = DriverManager.getConnection(
+			"jdbc:mysql://localhost/springbook", "spring", "book");
+
+		Statement statement = con.createStatement();
+		statement.execute("Truncate table users");
+		con.close();
+	}
+
+
+}

--- a/src/main/java/springbook/vol1/ch1/domain/User.java
+++ b/src/main/java/springbook/vol1/ch1/domain/User.java
@@ -1,0 +1,14 @@
+package springbook.vol1.ch1.domain;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class User {
+
+	private String id;
+	private String name;
+	private String password;
+
+}

--- a/src/test/java/springbook/vol1/ch1/dao/UserDaoTest.java
+++ b/src/test/java/springbook/vol1/ch1/dao/UserDaoTest.java
@@ -1,0 +1,46 @@
+package springbook.vol1.ch1.dao;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.sql.SQLException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import springbook.vol1.ch1.domain.User;
+
+@DisplayName("ch 1-1 UserDaoTest 클래스")
+class UserDaoTest {
+
+	private UserDao dao = new UserDao();
+
+	@BeforeEach
+	void setUp() throws SQLException {
+		dao.clean();
+	}
+
+	@Test
+	void 유저생성과_조회_성공() throws SQLException {
+		User user = new User();
+		user.setId("kukim");
+		user.setName("쿠킴");
+		user.setPassword("1234");
+		dao.add(user);
+
+		User findUser = dao.get("kukim");
+
+		assertAll(
+			() -> assertThat(findUser.getId()).isEqualTo(user.getId()),
+			() -> assertThat(findUser.getName()).isEqualTo(user.getName()),
+			() -> assertThat(findUser.getPassword()).isEqualTo(user.getPassword())
+		);
+	}
+
+	@Test
+	void 유저_조회_실패() {
+		assertThatThrownBy(() ->
+			dao.get("존재하지않는유저아이디"))
+			.isInstanceOf(SQLException.class);
+	}
+}


### PR DESCRIPTION
### 책과 다른 점
- main 문 대신 JUnit 5를 사용하여 테스트 작성
- UserDao 객체의 clear() 메서드 추가
- Class.forName("com.mysql.jdbc.Driver") 사용하여 드라이버 가져오지 않기

```java
/**
 * Backwards compatibility to support apps that call <code>Class.forName("com.mysql.jdbc.Driver");</code>.
 */
public class Driver extends com.mysql.cj.jdbc.Driver {
    public Driver() throws SQLException {
        super();
    }

    static {
        System.err.println("Loading class `com.mysql.jdbc.Driver'. This is deprecated. The new driver class is `com.mysql.cj.jdbc.Driver'. "
                + "The driver is automatically registered via the SPI and manual loading of the driver class is generally unnecessary.");
    }
}
```

SPI가 자동으로 로딩시켜준다고 함